### PR TITLE
Fixes incorrect tab type for checkboxes.

### DIFF
--- a/src/service/DocuSign_RequestSignatureService.php
+++ b/src/service/DocuSign_RequestSignatureService.php
@@ -226,7 +226,7 @@ class DocuSign_Recipient extends DocuSign_Model {
 		switch ($tabType) {
 			case 'textTabs':
 			case 'approveTabs':
-			case 'checkboxTab':
+			case 'checkboxTabs':
 			case 'companyTabs':
 			case 'dateSignedTabs':
 			case 'dateTabs':


### PR DESCRIPTION
There is a typo in the recent Tab work that prevents checkbox tabs from working correctly. This addresses that typo.
