### PR TITLE
Fix fatal error. It appears if tab list contains dropdown element.

### DIFF
--- a/src/Model/Tabs.php
+++ b/src/Model/Tabs.php
@@ -77,7 +77,7 @@ class Tabs implements ModelInterface, ArrayAccess
         'full_name_tabs' => '\DocuSign\eSign\Model\FullName[]',
         'initial_here_tabs' => '\DocuSign\eSign\Model\InitialHere[]',
         'last_name_tabs' => '\DocuSign\eSign\Model\LastName[]',
-        'list_tabs' => '\DocuSign\eSign\Model\array[]',
+        'list_tabs' => '\DocuSign\eSign\Model\ModelList[]',
         'notarize_tabs' => '\DocuSign\eSign\Model\Notarize[]',
         'notary_seal_tabs' => '\DocuSign\eSign\Model\NotarySeal[]',
         'note_tabs' => '\DocuSign\eSign\Model\Note[]',


### PR DESCRIPTION
I faced with some problem, when in documents I put dropdown tab. When I use your SDK I get fatal error when it tries to fetch tabs through rest api. I found you have unused model \DocuSign\eSign\Model\ModelLis. I sure this model fits better in this case than unexist model \DocuSign\eSign\Model\array.