### PR TITLE
Version 6.12.0-rc release

### DIFF
--- a/.swagger-codegen-ignore
+++ b/.swagger-codegen-ignore
@@ -35,7 +35,6 @@ LICENSE
 .travis.yml
 .php_cs
 autoload.php
-composer.json
 
 # Specific src and test files
 phpunit.xml.dist

--- a/.swagger-codegen-ignore
+++ b/.swagger-codegen-ignore
@@ -35,6 +35,7 @@ LICENSE
 .travis.yml
 .php_cs
 autoload.php
+composer.json
 
 # Specific src and test files
 phpunit.xml.dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@ All notable changes to this project will be documented in this file.
 
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
+## [v6.12.0-rc] - eSignature API v2.1-22.3.00.00 - 2022-11-08
+### Fixed
+- Issue - [`#172`](https://github.com/docusign/docusign-esign-php-client/issues/172):  Cannot install the last version due to the firebase/php-jwt version.
+- Issue - [`#174`](https://github.com/docusign/docusign-esign-php-client/issues/174):  Consider making firebase/php-jwt version requirement more relaxed.
+
 ## [v6.11.0] - eSignature API v2.1-22.3.00.00 - 2022-08-30
 ### Changed
-- Added support for version v2.1-22.3.00.00 of the DocuSign ESignature API.
+- Added support for version v2.1-1.2.7 of the DocuSign DBTest API.
 - Updated the SDK release version.
 
 ## [v6.10.0] - eSignature API v2.1-22.2.00.00 - 2022-06-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for
 
 ## [v6.11.0] - eSignature API v2.1-22.3.00.00 - 2022-08-30
 ### Changed
-- Added support for version v2.1-1.2.7 of the DocuSign DBTest API.
+- Added support for version v2.1-22.3.00.00 of the DocuSign ESignature API.
 - Updated the SDK release version.
 
 ## [v6.10.0] - eSignature API v2.1-22.2.00.00 - 2022-06-17

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "firebase/php-jwt": "^5.0"
+        "firebase/php-jwt": "^5.0 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",


### PR DESCRIPTION
### Changed
- Added support for version v2.1-1.2.7 of the DocuSign DBTest API.
- Updated the SDK release version.
